### PR TITLE
Use schematics as well as marshmallow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,14 @@ python:
   - 3.5
   - pypy
 
+env:
+  - SERIALIZATION_PKG="marshmallow==2.7.0"
+  - SERIALIZATION_PKG="schematics==1.0.4"
+
 install:
   - pip install -e .
   - pip install codecov pytest travis-sphinx
+  - pip install $SERIALIZATION_PKG
 
 script:
   - coverage run --source=dynamallow setup.py test

--- a/dynamallow/exc.py
+++ b/dynamallow/exc.py
@@ -1,0 +1,38 @@
+# --- Schema exceptions ---
+class MarshModelException(Exception):
+    """Base exception for MarshModel problems"""
+
+
+class ValidationError(MarshModelException):
+    """Schema validation failed"""
+    def __init__(self, raw, schema_name, errors, *args, **kwargs):
+        super(ValidationError, self).__init__(*args, **kwargs)
+        self.errors = errors
+        self.raw = raw
+        self.schema_name = schema_name
+
+    def __unicode__(self):
+        return 'Validation failed for data {} with schema {}. Errors: {}'.format(
+           self.raw, self.schema_name, self.errors
+        )
+
+
+# --- Table exceptions ---
+class DynamoTableException(Exception):
+    """Base exception class for all DynamoTable errors"""
+
+
+class MissingTableAttribute(DynamoTableException):
+    """A required attribute is missing"""
+
+
+class InvalidSchemaField(DynamoTableException):
+    """A field provided does not exist in the schema"""
+
+
+class InvalidKey(DynamoTableException):
+    """A parameter is not a valid key"""
+
+
+class HashKeyExists(DynamoTableException):
+    """A operating requesting a unique hash key failed"""

--- a/dynamallow/exceptions.py
+++ b/dynamallow/exceptions.py
@@ -22,6 +22,12 @@ class ValidationError(MarshModelException):
             self.schema_name, self.errors
         )
 
+    def __str__(self):
+        log.debug('Validation failure for data: {0}'.format(self.raw))
+        return 'Validation failed for schema {0}. Errors: {1}'.format(
+            self.schema_name, self.errors
+        )
+
 
 # --- Table exceptions ---
 class DynamoTableException(Exception):

--- a/dynamallow/exceptions.py
+++ b/dynamallow/exceptions.py
@@ -1,3 +1,8 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
 # --- Schema exceptions ---
 class MarshModelException(Exception):
     """Base exception for MarshModel problems"""
@@ -12,8 +17,9 @@ class ValidationError(MarshModelException):
         self.schema_name = schema_name
 
     def __unicode__(self):
-        return 'Validation failed for data {} with schema {}. Errors: {}'.format(
-           self.raw, self.schema_name, self.errors
+        log.debug('Validation failure for data: {0}'.format(self.raw))
+        return 'Validation failed for schema {0}. Errors: {1}'.format(
+            self.schema_name, self.errors
         )
 
 

--- a/dynamallow/local.py
+++ b/dynamallow/local.py
@@ -1,0 +1,80 @@
+import os
+import random
+import socket
+import tarfile
+import tempfile
+
+import subprocess
+
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+
+class DynamoLocal(object):
+    """
+    Spins up a local dynamo instance. This should ONLY be used for testing!! You must call
+    ``dynamo_local.shutdown()`` when you are done with the instance.
+    """
+    def __init__(self, dynamo_dir, port=None, log=None):
+        self.port = port or self._get_random_port()
+        if not os.path.isdir(dynamo_dir):
+            if log:
+                log.info("Creating dynamo_local_dir: {0}".format(dynamo_dir))
+            assert not os.path.exists(dynamo_dir)
+            os.makedirs(dynamo_dir, 0o755)
+
+        if not os.path.exists(os.path.join(dynamo_dir, 'DynamoDBLocal.jar')):
+            temp_fd, temp_file = tempfile.mkstemp()
+            os.close(temp_fd)
+            if log:
+                log.info("Downloading dynamo local to: {0}".format(temp_file))
+            urlretrieve(
+                'http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz',
+                temp_file
+            )
+
+            log.info("Extracting dynamo local...")
+            archive = tarfile.open(temp_file, 'r:gz')
+            archive.extractall(dynamo_dir)
+            archive.close()
+
+            os.unlink(temp_file)
+
+        if log:
+            log.info("Running dynamo from {dir} on port {port}".format(
+                dir=dynamo_dir,
+                port=self.port
+            ))
+        self.dynamo_proc = subprocess.Popen(
+            (
+                'java',
+                '-Djava.library.path=./DynamoDBLocal_lib',
+                '-jar', 'DynamoDBLocal.jar',
+                '-sharedDb',
+                '-inMemory',
+                '-port', str(self.port)
+            ),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=dynamo_dir
+        )
+
+    def shutdown(self):
+        self.dynamo_proc.terminate()
+        self.dynamo_proc.wait()
+
+    @staticmethod
+    def _get_random_port():
+        """Find a random port that appears to be available"""
+        random_port = random.randint(25000, 55000)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            result = sock.connect_ex(('127.0.0.1', random_port))
+        finally:
+            sock.close()
+        if result == 0:
+            return DynamoLocal._get_random_port()
+        return random_port
+

--- a/dynamallow/model.py
+++ b/dynamallow/model.py
@@ -18,7 +18,7 @@ import six
 
 from .table import DynamoTable3
 from .types import Model
-from .exc import MarshModelException
+from .exceptions import MarshModelException
 
 log = logging.getLogger(__name__)
 

--- a/dynamallow/table.py
+++ b/dynamallow/table.py
@@ -30,7 +30,7 @@ import botocore
 import six
 
 from boto3.dynamodb.conditions import Key, Attr
-from dynamallow.exc import MissingTableAttribute, InvalidSchemaField, HashKeyExists
+from dynamallow.exceptions import MissingTableAttribute, InvalidSchemaField, HashKeyExists
 
 log = logging.getLogger(__name__)
 

--- a/dynamallow/table.py
+++ b/dynamallow/table.py
@@ -23,7 +23,6 @@ write      True      int   The provisioned write throughput.
 
 """
 
-import inspect
 import logging
 
 import boto3
@@ -31,39 +30,9 @@ import botocore
 import six
 
 from boto3.dynamodb.conditions import Key, Attr
-
-from marshmallow import fields
+from dynamallow.exc import MissingTableAttribute, InvalidSchemaField, HashKeyExists
 
 log = logging.getLogger(__name__)
-
-
-def _field_to_dynamo_type(field):
-    """Given a marshmallow field object return the appropriate Dynamo type character"""
-    if isinstance(field, fields.Raw):
-        return 'B'
-    if isinstance(field, fields.Number):
-        return 'N'
-    return 'S'
-
-
-class DynamoTableException(Exception):
-    """Base exception class for all DynamoTable errors"""
-
-
-class MissingTableAttribute(DynamoTableException):
-    """A required attribute is missing"""
-
-
-class InvalidSchemaField(DynamoTableException):
-    """A field provided does not exist in the schema"""
-
-
-class InvalidKey(DynamoTableException):
-    """A parameter is not a valid key"""
-
-
-class HashKeyExists(DynamoTableException):
-    """A operating requesting a unique hash key failed"""
 
 
 class DynamoTable3(object):
@@ -90,17 +59,17 @@ class DynamoTable3(object):
             if not hasattr(self, attr):
                 setattr(self, attr, None)
 
-        if self.hash_key not in self.schema.fields:
+        if self.hash_key not in self.schema.dynamallow_fields():
             raise InvalidSchemaField("The hash key '{0}' does not exist in the schema".format(self.hash_key))
 
-        if self.range_key and self.range_key not in self.schema.fields:
+        if self.range_key and self.range_key not in self.schema.dynamallow_fields():
             raise InvalidSchemaField("The range key '{0}' does not exist in the schema".format(self.range_key))
 
     @classmethod
     def get_resource(cls, **kwargs):
         """Return the boto3 dynamodb resource, create it if it doesn't exist
 
-        The resource is stored globally on the ``DynamoTable3`` class and is shared between all models.  To influence
+        The resource is stored globally on the ``DynamoTable3`` class and is shared between all models. To influence
         the connection parameters you just need to call ``get_resource`` on any model with the correct kwargs BEFORE you
         use any of the models.
         """
@@ -140,10 +109,10 @@ class DynamoTable3(object):
     @property
     def attribute_definitions(self):
         """Return an appropriate AttributeDefinitions, based on our key attributes and the schema object"""
-        as_def = lambda name, field: {'AttributeName': name, 'AttributeType': _field_to_dynamo_type(field)}
-        defs = [as_def(self.hash_key, self.schema.fields[self.hash_key])]
+        as_def = lambda name, field: {'AttributeName': name, 'AttributeType': self.schema.field_to_dynamo_type(field)}
+        defs = [as_def(self.hash_key, self.schema.dynamallow_fields()[self.hash_key])]
         if self.range_key:
-            defs.append(as_def(self.range_key, self.schema.fields[self.range_key]))
+            defs.append(as_def(self.range_key, self.schema.dynamallow_fields()[self.range_key]))
         return defs
 
     @property
@@ -177,11 +146,10 @@ class DynamoTable3(object):
             table.meta.client.get_waiter('table_exists').wait(TableName=self.name)
         return table
 
-
     def delete(self, wait=True):
         """Delete this existing table
 
-        :param bool wait: If set to True, the default, this call will block until the table is created
+        :param bool wait: If set to True, the default, this call will block until the table is deleted
         """
         self.table.delete()
         if wait:
@@ -214,7 +182,7 @@ class DynamoTable3(object):
 
     def get(self, consistent=False, **kwargs):
         for k, v in six.iteritems(kwargs):
-            if k not in self.schema.fields:
+            if k not in self.schema.dynamallow_fields():
                 raise InvalidSchemaField("{0} does not exist in the schema fields".format(k))
         if consistent:
             kwargs['ConsistentRead'] = True

--- a/dynamallow/types/__init__.py
+++ b/dynamallow/types/__init__.py
@@ -1,0 +1,8 @@
+from .base import BaseModel
+try:
+    from ._schematics import Model
+except ImportError:
+    try:
+        from ._marshmallow import Model
+    except ImportError:
+        raise ImportError('One of marshmallow or schematics is required to use this library.')

--- a/dynamallow/types/_marshmallow.py
+++ b/dynamallow/types/_marshmallow.py
@@ -2,7 +2,7 @@ from marshmallow import Schema as MarshmallowModel
 from marshmallow import fields
 
 from .base import BaseModel as BaseModel
-from ..exc import ValidationError as ValidationError
+from ..exceptions import ValidationError as ValidationError
 
 
 class Model(MarshmallowModel, BaseModel):

--- a/dynamallow/types/_marshmallow.py
+++ b/dynamallow/types/_marshmallow.py
@@ -1,0 +1,32 @@
+from marshmallow import Schema as MarshmallowModel
+from marshmallow import fields
+
+from .base import BaseModel as BaseModel
+from ..exc import ValidationError as ValidationError
+
+
+class Model(MarshmallowModel, BaseModel):
+    """``Model`` is the base class for marshmallow based schemas """
+    _dynamallow_fields = None
+
+    @staticmethod
+    def field_to_dynamo_type(field):
+        """Given a marshmallow field object return the appropriate Dynamo type character"""
+        if isinstance(field, fields.Raw):
+            return 'B'
+        if isinstance(field, fields.Number):
+            return 'N'
+        return 'S'
+
+    @classmethod
+    def dynamallow_fields(cls):
+        if cls._dynamallow_fields is None:
+            cls._dynamallow_fields = cls().fields
+        return cls._dynamallow_fields
+
+    @classmethod
+    def dynamallow_validate(cls, obj):
+        data, errors = cls().load(obj)
+        if errors:
+            raise ValidationError(obj, cls.__name__, errors)
+        return data

--- a/dynamallow/types/_schematics.py
+++ b/dynamallow/types/_schematics.py
@@ -3,7 +3,7 @@ from schematics.exceptions import ValidationError as SchematicsValidationError, 
 from schematics import types
 
 from .base import BaseModel as _BaseModel
-from ..exc import ValidationError as _ValidationError
+from ..exceptions import ValidationError as _ValidationError
 
 
 class Model(SchematicsModel, _BaseModel):

--- a/dynamallow/types/_schematics.py
+++ b/dynamallow/types/_schematics.py
@@ -1,0 +1,28 @@
+from schematics.models import Model as SchematicsModel
+from schematics.exceptions import ValidationError as SchematicsValidationError, ModelConversionError
+from schematics import types
+
+from .base import BaseModel as _BaseModel
+from ..exc import ValidationError as _ValidationError
+
+
+class Model(SchematicsModel, _BaseModel):
+    """``Model`` is the base class for schematics_ based schemas """
+    @staticmethod
+    def field_to_dynamo_type(field):
+        """Given a schematics field object return the appropriate Dynamo type character"""
+        # XXX: Schematics does not currently have a "raw" type that would map to Dynamo's 'B' (binary) type.
+        if isinstance(field, types.NumberType):
+            return 'N'
+        return 'S'
+
+    @classmethod
+    def dynamallow_fields(cls):
+        return cls.fields
+
+    @classmethod
+    def dynamallow_validate(cls, obj):
+        try:
+            return cls(obj, strict=False).to_primitive()
+        except (SchematicsValidationError, ModelConversionError) as e:
+            raise _ValidationError(obj, cls.__name__, e.messages)

--- a/dynamallow/types/base.py
+++ b/dynamallow/types/base.py
@@ -15,7 +15,7 @@ class BaseModel(object):
     @classmethod
     def dynamallow_fields(cls):
         """ Returns a dictionary of key value pairs where keys are attributes and values are type classes """
-        raise NotImplementedError('{} class must implement dynamallow_fields'.format(cls.__name__))
+        raise NotImplementedError('{0} class must implement dynamallow_fields'.format(cls.__name__))
 
     @classmethod
     def dynamallow_validate(cls, obj):
@@ -26,4 +26,4 @@ class BaseModel(object):
         Returns a dictionary representing the sanitized input ``obj``. On validation failure,
         this should raise ``dynamallow.exc.ValidationError``.
         """
-        raise NotImplementedError('{} class must implement dynamallow_validate'.format(cls.__name__))
+        raise NotImplementedError('{0} class must implement dynamallow_validate'.format(cls.__name__))

--- a/dynamallow/types/base.py
+++ b/dynamallow/types/base.py
@@ -1,0 +1,29 @@
+class BaseModel(object):
+    """``BaseModel`` is the base class for ``types.Model``. It must define ``dynamallow_validate`` which runs validation
+    in your desired serialization library, ``dynamallow_fields`` which returns a dictionary of key value pairs
+    where keys are attributes and values are the type of the attribute, and ``field_to_dynamo_type`` which returns
+    the dynamo type character for the input type (we implement schematics_ and marshmallow_).
+
+    .. _schematics: https://schematics.readthedocs.io/en/latest/
+    .. _marshmallow: https://marshmallow.readthedocs.io/en/latest/
+    """
+    @staticmethod
+    def field_to_dynamo_type(field):
+        """ Returns the dynamo type character given the field. """
+        raise NotImplementedError('Child class must implement field_to_dynamo_type')
+
+    @classmethod
+    def dynamallow_fields(cls):
+        """ Returns a dictionary of key value pairs where keys are attributes and values are type classes """
+        raise NotImplementedError('{} class must implement dynamallow_fields'.format(cls.__name__))
+
+    @classmethod
+    def dynamallow_validate(cls, obj):
+        """
+        Given a dictionary representing a blob from dynamo, this method will validate the blob
+        given the desired validation library.
+
+        Returns a dictionary representing the sanitized input ``obj``. On validation failure,
+        this should raise ``dynamallow.exc.ValidationError``.
+        """
+        raise NotImplementedError('{} class must implement dynamallow_validate'.format(cls.__name__))

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ with open('README.rst', 'r') as readme_fd:
 
 setup(
     name='dynamallow',
-    version='0.0.1',
+    version='0.0.2',
 
-    description='Python ORM style interface to Amazon (AWS) DynamoDB using Marshmallow for Schema validation',
+    description='Python ORM style interface to Amazon (AWS) DynamoDB using Schematics or Marshmallow for Schema validation',
     long_description=long_description,
     author='Evan Borgstrom',
     author_email='evan@borgstrom.ca',
@@ -19,7 +19,6 @@ setup(
     ],
     install_requires=[
         'boto3>=1.3,<1.4',
-        'marshmallow>=2.7.0,<2.8.0',
         'pytest>=2.9,<3.0',
         'six',
     ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,5 @@
 import logging
 import os
-import random
-import socket
-import subprocess
-import tarfile
-import tempfile
 
 try:
     from urllib import urlretrieve
@@ -14,8 +9,7 @@ except ImportError:
 import pytest
 
 from dynamallow import MarshModel  # , LocalIndex, GlobalIndex
-
-from marshmallow import fields
+from dynamallow import local
 
 log = logging.getLogger(__name__)
 
@@ -24,32 +18,65 @@ log = logging.getLogger(__name__)
 def TestModel():
     """Provides a test model"""
 
-    class TestModel(MarshModel):
-        class Table:
-            name = 'peanut-butter'
-            hash_key = 'foo'
-            range_key = 'bar'
-            read = 5
-            write = 5
+    if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+        from marshmallow import fields
 
-            """
-            class Bazillions(LocalIndex):
+        class TestModel(MarshModel):
+            class Table:
+                name = 'peanut-butter'
+                hash_key = 'foo'
+                range_key = 'bar'
                 read = 5
                 write = 5
-            """
 
-        class Schema:
-            foo = fields.String(required=True)
-            bar = fields.String(required=True)
-            baz = fields.String()
-            count = fields.Integer()
-            child = fields.Dict()
+                """
+                class Bazillions(LocalIndex):
+                    read = 5
+                    write = 5
+                """
 
-        def business_logic(self):
-            return 'http://art.lawver.net/funny/internet.jpg?foo={foo}&bar={bar}'.format(
-                foo=self.foo,
-                bar=self.bar
-            )
+            class Schema:
+                foo = fields.String(required=True)
+                bar = fields.String(required=True)
+                baz = fields.String()
+                count = fields.Integer()
+                child = fields.Dict()
+
+            def business_logic(self):
+                return 'http://art.lawver.net/funny/internet.jpg?foo={foo}&bar={bar}'.format(
+                    foo=self.foo,
+                    bar=self.bar
+                )
+    else:
+        from schematics import types
+        from schematics.types import compound
+
+        class TestModel(MarshModel):
+            class Table:
+                name = 'peanut-butter'
+                hash_key = 'foo'
+                range_key = 'bar'
+                read = 5
+                write = 5
+
+                """
+                class Bazillions(LocalIndex):
+                    read = 5
+                    write = 5
+                """
+
+            class Schema:
+                foo = types.StringType(required=True)
+                bar = types.StringType(required=True)
+                baz = types.StringType()
+                count = types.IntType()
+                child = compound.DictType(types.StringType)
+
+            def business_logic(self):
+                return 'http://art.lawver.net/funny/internet.jpg?foo={foo}&bar={bar}'.format(
+                    foo=self.foo,
+                    bar=self.bar
+                )
 
     return TestModel
 
@@ -74,69 +101,12 @@ def TestModel_entries(TestModel, TestModel_table):
 def dynamo_local(request, TestModel):
     """Connect to a local dynamo instance"""
     dynamo_local_dir = os.environ.get('DYNAMO_LOCAL', 'build/dynamo-local')
-
-    if not os.path.isdir(dynamo_local_dir):
-        log.info("Creating dynamo_local_dir: {0}".format(dynamo_local_dir))
-        assert not os.path.exists(dynamo_local_dir)
-        os.makedirs(dynamo_local_dir, 0o755)
-
-    if not os.path.exists(os.path.join(dynamo_local_dir, 'DynamoDBLocal.jar')):
-        temp_fd, temp_file = tempfile.mkstemp()
-        os.close(temp_fd)
-        log.info("Downloading dynamo local to: {0}".format(temp_file))
-        urlretrieve(
-            'http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz',
-            temp_file
-        )
-
-        log.info("Extracting dynamo local...")
-        archive = tarfile.open(temp_file, 'r:gz')
-        archive.extractall(dynamo_local_dir)
-        archive.close()
-
-        os.unlink(temp_file)
-
-    def get_random_port():
-        """Find a random port that appears to be available"""
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        random_port = random.randint(25000, 55000)
-        result = sock.connect_ex(('127.0.0.1', random_port))
-        sock.close()
-        if result == 0:
-            return get_random_port()
-        return random_port
-
-    random_port = get_random_port()
-
-    log.info("Running dynamo from {dir} on port {port}".format(
-        dir=dynamo_local_dir,
-        port=random_port
-    ))
-
-    dynamo_proc = subprocess.Popen(
-        (
-            'java',
-            '-Djava.library.path=./DynamoDBLocal_lib',
-            '-jar', 'DynamoDBLocal.jar',
-            '-sharedDb',
-            '-inMemory',
-            '-port', str(random_port)
-        ),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=dynamo_local_dir
-    )
-
-    def shutdown_dynamo():
-        dynamo_proc.terminate()
-        dynamo_proc.wait()
-    request.addfinalizer(shutdown_dynamo)
-
+    dynamo_local_ = local.DynamoLocal(dynamo_local_dir, log=log)
+    request.addfinalizer(dynamo_local_.shutdown)
     TestModel.Table.get_resource(
         aws_access_key_id="anything",
         aws_secret_access_key="anything",
         region_name="us-west-2",
-        endpoint_url="http://localhost:{port}".format(port=random_port)
+        endpoint_url="http://localhost:{port}".format(port=dynamo_local_.port)
     )
-
-    return random_port
+    return dynamo_local_.port

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,8 +101,7 @@ def TestModel_entries(TestModel, TestModel_table):
 def dynamo_local(request, TestModel):
     """Connect to a local dynamo instance"""
     dynamo_local_dir = os.environ.get('DYNAMO_LOCAL', 'build/dynamo-local')
-    dynamo_local_ = local.DynamoLocal(dynamo_local_dir, log=log)
-    request.addfinalizer(dynamo_local_.shutdown)
+    dynamo_local_ = local.DynamoLocal(dynamo_local_dir)
     TestModel.Table.get_resource(
         aws_access_key_id="anything",
         aws_secret_access_key="anything",

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,0 +1,29 @@
+import os
+import socket
+import time
+
+from dynamallow.local import DynamoLocal
+
+
+def test_shutdown_local_dynamo():
+    dynamo_local_dir = os.environ.get('DYNAMO_LOCAL', 'build/dynamo-local')
+    dynamo_local = DynamoLocal(dynamo_local_dir)
+    connected = -1
+    for _ in range(5):
+        connected = _connect_to_port(dynamo_local.port)
+        if connected == 0:
+            break
+        time.sleep(0.5)
+    assert connected == 0
+    dynamo_local.shutdown()
+    assert dynamo_local.dynamo_proc is None
+    assert _connect_to_port(dynamo_local.port) != 0
+
+
+def _connect_to_port(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        result = sock.connect_ex(('127.0.0.1', port))
+    finally:
+        sock.close()
+    return result

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,8 +5,10 @@ from dynamallow.model import MarshModel
 from dynamallow.exceptions import InvalidSchemaField, MissingTableAttribute, MarshModelException
 if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
     from marshmallow.fields import String
+    from marshmallow.fields import Number
 else:
     from schematics.types import StringType as String
+    from schematics.types import IntType as Number
 
 
 def test_missing_inner_classes():
@@ -72,3 +74,20 @@ def test_invalid_range_key():
             class Schema:
                 foo = String(required=True)
                 baz = String(required=True)
+
+
+def test_number_hash_key():
+    """Test a number hash key and ensure the dynamo type gets set correctly"""
+    class Model(MarshModel):
+        class Table:
+            name = 'table'
+            hash_key = 'foo'
+            read = 1
+            write = 1
+
+        class Schema:
+            foo = Number(required=True)
+            baz = String(required=True)
+
+    model = Model(foo=1, baz='foo')
+    assert model.Table.attribute_definitions == [{'AttributeName': 'foo', 'AttributeType': 'N'}]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,9 +1,12 @@
+import os
 import pytest
 
-from marshmallow import fields
-
-from dynamallow.model import MarshModel, MarshModelException
-from dynamallow.table import InvalidSchemaField, MissingTableAttribute
+from dynamallow.model import MarshModel
+from dynamallow.exc import InvalidSchemaField, MissingTableAttribute, MarshModelException
+if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
+    from marshmallow.fields import String
+else:
+    from schematics.types import StringType as String
 
 
 def test_missing_inner_classes():
@@ -38,7 +41,7 @@ def test_table_validation():
                 hash_key = 'foo'
 
             class Schema:
-                foo = fields.String(required=True)
+                foo = String(required=True)
 
 
 def test_invalid_hash_key():
@@ -52,7 +55,7 @@ def test_invalid_hash_key():
                 write = 1
 
             class Schema:
-                bar = fields.String(required=True)
+                bar = String(required=True)
 
 
 def test_invalid_range_key():
@@ -67,5 +70,5 @@ def test_invalid_range_key():
                 write = 1
 
             class Schema:
-                foo = fields.String(required=True)
-                baz = fields.String(required=True)
+                foo = String(required=True)
+                baz = String(required=True)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 from dynamallow.model import MarshModel
-from dynamallow.exc import InvalidSchemaField, MissingTableAttribute, MarshModelException
+from dynamallow.exceptions import InvalidSchemaField, MissingTableAttribute, MarshModelException
 if 'marshmallow' in (os.getenv('SERIALIZATION_PKG') or ''):
     from marshmallow.fields import String
 else:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,18 +1,7 @@
 """These tests require dynamo local running"""
-import inspect
 import pytest
 
-from marshmallow import fields
-
-from dynamallow.table import HashKeyExists, InvalidSchemaField, _field_to_dynamo_type
-
-
-def test_field_to_dynamo_type():
-    """Field to dynamo type should map as expected"""
-    assert _field_to_dynamo_type(fields.Number()) == 'N'
-    assert _field_to_dynamo_type(fields.Decimal()) == 'N'
-    assert _field_to_dynamo_type(fields.Raw()) == 'B'
-    assert _field_to_dynamo_type(fields.DateTime()) == 'S'
+from dynamallow.exc import HashKeyExists, InvalidSchemaField, ValidationError
 
 
 def test_table_creation_deletion(TestModel, dynamo_local):
@@ -30,6 +19,22 @@ def test_put_get(TestModel, TestModel_table, dynamo_local):
     first_one = TestModel.get(foo="first", bar="one")
     assert isinstance(first_one, TestModel)
     assert first_one.baz == 'lol' and first_one.count == 123
+
+def test_schema_change(TestModel, TestModel_table, dynamo_local):
+    """Simulate a schema change and make sure we get the record correctly"""
+    data = {'foo': '1', 'bar': '2', 'bad_key': 10}
+    TestModel.Table.put(data)
+    item = TestModel.get(foo='1', bar='2')
+    assert item._raw == data
+    assert item.foo == '1'
+    assert item.bar == '2'
+    assert not hasattr(item, 'bad_key')
+
+
+def test_put_invalid_schema(TestModel, TestModel_table, dynamo_local):
+    """Putting an invalid schema should raise a ``ValidationError``."""
+    with pytest.raises(ValidationError):
+        TestModel.put({"foo": [1], "bar": '10'})
 
 
 def test_put_batch(TestModel, TestModel_table, dynamo_local):
@@ -136,3 +141,31 @@ def test_overwrite(TestModel, TestModel_entries, dynamo_local):
 
     first_one = TestModel.get(foo="first", bar="one")
     assert first_one.count == 999
+
+
+def test_save(TestModel, TestModel_table, dynamo_local):
+    test_model = TestModel(foo='a', bar='b', count=100)
+    test_model.save()
+    result = TestModel.get(foo='a', bar='b')
+    assert result.foo == 'a'
+    assert result.bar == 'b'
+    assert result.count == 100
+
+    test_model.count += 1
+    test_model.baz = 'hello_world'
+    test_model.save()
+    result = TestModel.get(foo='a', bar='b')
+    assert result.foo == 'a'
+    assert result.bar == 'b'
+    assert result.count == 101
+    assert result.baz == 'hello_world'
+
+
+def test_save_update(TestModel, TestModel_entries, dynamo_local):
+    result = TestModel.get(foo='first', bar='one')
+    assert result.baz == 'bbq'
+    result.baz = 'changed'
+    result.save()
+
+    result = TestModel.get(foo='first', bar='one')
+    assert result.baz == 'changed'

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,7 +1,7 @@
 """These tests require dynamo local running"""
 import pytest
 
-from dynamallow.exc import HashKeyExists, InvalidSchemaField, ValidationError
+from dynamallow.exceptions import HashKeyExists, InvalidSchemaField, ValidationError
 
 
 def test_table_creation_deletion(TestModel, dynamo_local):


### PR DESCRIPTION
/review @borgstrom 

I have updated dynamallow to use [schematics](https://schematics.readthedocs.io/en/latest/) instead of marshmallow. There are a few outstanding tasks before this can get merged, but just wanted to open it up for early review to see if you had any feedback on the core code. All the tests are passing, so this should be code complete.

Things to note:
- Wrapped schematics types with our own type classes so we have more control over any type specific metadata. Also moved the dynamo_type into our type class.

Outstanding tasks:
- Update docs
- Do we want to rename the repository/library?
- How do you want to version bump this? As it is in alpha, I've only version bumped a minor version, but this clearly has breaking changes. Also, I'm assuming this will depend on whether or not we rename.