### PR TITLE
Need to include the types package so this installs correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 with open('README.rst', 'r') as readme_fd:
     long_description = readme_fd.read()
 
 setup(
     name='dynamallow',
-    version='0.0.2',
+    version='0.0.3',
 
     description='Python ORM style interface to Amazon (AWS) DynamoDB using Schematics or Marshmallow for Schema validation',
     long_description=long_description,
@@ -22,10 +22,7 @@ setup(
         'pytest>=2.9,<3.0',
         'six',
     ],
-    packages=[
-        'dynamallow',
-    ],
-
+    packages=find_packages('.', exclude=['tests', 'docs']),
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -4,16 +4,19 @@ import time
 
 from dynamallow.local import DynamoLocal
 
+DYNAMO_CONN_RETRIES = 10
+DYNAMO_CONN_SLEEP = 1
+
 
 def test_shutdown_local_dynamo():
     dynamo_local_dir = os.environ.get('DYNAMO_LOCAL', 'build/dynamo-local')
     dynamo_local = DynamoLocal(dynamo_local_dir)
     connected = -1
-    for _ in range(5):
+    for _ in range(DYNAMO_CONN_RETRIES):
         connected = _connect_to_port(dynamo_local.port)
         if connected == 0:
             break
-        time.sleep(0.5)
+        time.sleep(DYNAMO_CONN_SLEEP)
     assert connected == 0
     dynamo_local.shutdown()
     assert dynamo_local.dynamo_proc is None


### PR DESCRIPTION
Not sure why `pip install -e` worked without this, but it looks like pypi is not installing the `types`module. We need to explicitly include it here.